### PR TITLE
注明 qqqun 与 qqfriend 原始代码出处

### DIFF
--- a/Spiders/qqfriend/main.py
+++ b/Spiders/qqfriend/main.py
@@ -1,3 +1,8 @@
+# author: cjh0613 
+# https://cjh0613.com/20200520getQQmembers.html
+# From: https://github.com/cjh0613/python-pub/blob/1c308fe90386f6d6e69e2202bb0c4acd4857576f/%E8%8E%B7%E5%8F%96QQ%E5%A5%BD%E5%8F%8B%E5%88%97%E8%A1%A8.py
+# modified by kangvcar
+
 import selenium
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options

--- a/Spiders/qqqun/main.py
+++ b/Spiders/qqqun/main.py
@@ -1,4 +1,9 @@
 # -*- coding: utf-8 -*-
+# author: cjh0613  
+# https://cjh0613.com/20200520getQQmembers.html
+# From: https://github.com/cjh0613/python-pub/blob/1c308fe90386f6d6e69e2202bb0c4acd4857576f/%E8%8E%B7%E5%8F%96QQ%E7%BE%A4%E6%88%90%E5%91%98%E5%88%97%E8%A1%A8.py
+# modified by kangvcar
+
 import selenium
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options


### PR DESCRIPTION
补充 qqqun 与 qqfriend 原始代码出处。

我已声明过许可协议：代码采用 [AGPL-3.0 License](https://github.com/cjh0613/python-pub/blob/master/LICENSE) 许可协议；文章采用 [BY\-NC\-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh) 许可协议。

谢谢。